### PR TITLE
Add testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 /dist
 /pdf_redactor.egg-info
 /.eggs
+/.tox

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__
 *.pyc
+/build
+/dist
+/pdf_redactor.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 /build
 /dist
 /pdf_redactor.egg-info
+/.eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: false
+addons:
+  apt:
+    packages:
+    - poppler-utils
 language: python
 python:
   - "2.7"

--- a/example.py
+++ b/example.py
@@ -31,7 +31,7 @@ options.xmp_filters = [lambda xml : None]
 options.content_filters = [
 	# First convert all dash-like characters to dashes.
 	(
-		re.compile(r"[−–—~‐]"),
+		re.compile(u"[−–—~‐]"),
 		lambda m : "-"
 	),
 

--- a/pdf_redactor.py
+++ b/pdf_redactor.py
@@ -20,12 +20,8 @@ class RedactorOptions:
 	"""Redaction and I/O options."""
 
 	# Input/Output
-	if sys.version_info < (3,):
-		input_stream = sys.stdin # input stream containing the PDF to redact
-		output_stream = sys.stdout # output stream to write the new, redacted PDF to
-	else:
-		input_stream = sys.stdin.buffer # input byte stream containing the PDF to redact
-		output_stream = sys.stdout.buffer # output byte stream to write the new, redacted PDF to
+	input_stream = None
+	output_stream = None
 
 	# Metadata filters map names of entries in the PDF Document Information Dictionary
 	# (e.g. "Title", "Author", "Subject", "Keywords", "Creator", "Producer", "CreationDate",
@@ -81,6 +77,17 @@ class RedactorOptions:
 
 def redactor(options):
 	# This is the function that performs redaction.
+
+	if sys.version_info < (3,):
+		if options.input_stream is None:
+			options.input_stream = sys.stdin # input stream containing the PDF to redact
+		if options.output_stream is None:
+			options.output_stream = sys.stdout # output stream to write the new, redacted PDF to
+	else:
+		if options.input_stream is None:
+			options.input_stream = sys.stdin.buffer # input byte stream containing the PDF to redact
+		if options.output_stream is None:
+			options.output_stream = sys.stdout.buffer # output byte stream to write the new, redacted PDF to
 
 	from pdfrw import PdfReader, PdfWriter
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/pmaupin/pdfrw
+pdfrw>=0.3
 defusedxml

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,25 @@ setup(
 	description=' A general purpose PDF text-layer redaction tool for Python 2/3.',
 	author='Joshua Tauberer',
 	author_email='jt@occams.info',
-	long_description=open('README.md', 'r').read(),
+	long_description='''
+	A general-purpose PDF text-layer redaction tool, in pure Python, by Joshua Tauberer and Antoine McGrath.
+
+	pdf-redactor uses pdfrw under the hood to parse and write out the PDF.
+
+	This Python module is a general tool to help you automatically redact text from PDFs. The tool operates on:
+
+	* the text layer of the document's pages (content stream text)
+	* the Document Information Dictionary, a.k.a. the PDF metadata like Title and Author
+	* embedded XMP metadata, if present
+
+	Graphical elements, images, and other embedded resources are not touched.
+
+	You can:
+
+	* Use regular expressions to perform text substitution on the text layer (e.g. replace social security numbers with "XXX-XX-XXXX").
+	* Rewrite, remove, or add new metadata fields on a field-by-field basis (e.g. wipe out all metadata except for certain fields).
+	* Rewrite, remove, or add XML metadata using functions that operate on the parsed XMP DOM (e.g. wipe out XMP metadata).
+	''',
 	url='https://github.com/JoshData/pdf-redactor',
 	py_modules=['pdf_redactor'],
 	classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup
+
+setup(
+	name='pdf-redactor',
+	version='0.0.1',
+	description=' A general purpose PDF text-layer redaction tool for Python 2/3.',
+	author='Joshua Tauberer',
+	author_email='jt@occams.info',
+	long_description=open('README.md', 'r').read(),
+	url='https://github.com/JoshData/pdf-redactor',
+	py_modules=['pdf_redactor'],
+	classifiers=[
+		'Development Status :: 4 - Beta',
+		'Intended Audience :: Developers',
+		'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
+		'Operating System :: OS Independent',
+		'Programming Language :: Python',
+		'Programming Language :: Python :: 2',
+		'Programming Language :: Python :: 3',
+		'Topic :: Office/Business',
+		'Topic :: Software Development :: Libraries',
+		'Topic :: Software Development :: Libraries :: Python Modules',
+		'Topic :: Utilities',
+	],
+	install_requires=[
+		'pdfrw>=0.3',
+		'defusedxml',
+	],
+)

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,9 @@ setup(
 		'pdfrw>=0.3',
 		'defusedxml',
 	],
+	tests_require=[
+		'nose',
+		'textract',
+	],
+	test_suite='tests.run_tests.main',
 )

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import nose
+import os
+import sys
+
+
+def main(argv=None):
+	if argv is None:
+		argv = ["nosetests"]
+	path = os.path.abspath(os.path.dirname(__file__))
+	nose.run_exit(argv=argv, defaultTest=path)
+
+if __name__ == "__main__":
+	main(sys.argv)

--- a/tests/test_redactor.py
+++ b/tests/test_redactor.py
@@ -23,7 +23,7 @@ class RedactorTest(unittest.TestCase):
 				options.output_stream = redacted_file
 				options.content_filters = [
 					(
-						re.compile(r"[−–—~‐]"),
+						re.compile(u"[−–—~‐]"),
 						lambda m: "-"
 					),
 					(

--- a/tests/test_redactor.py
+++ b/tests/test_redactor.py
@@ -1,6 +1,7 @@
 import os
 import pkg_resources
 import re
+import subprocess
 import tempfile
 import textract
 import unittest
@@ -35,6 +36,32 @@ class RedactorTest(unittest.TestCase):
 
 				text = textract.process(redacted_path)
 				self.assertIn(b"Here are some fake SSNs\n\nXXX-XX-XXXX\n--\n\nXXX-XX-XXXX XXX-XX-XXXX\n\nAnd some more with common OCR character substitutions:\nXXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX", text)
+		finally:
+			redacted_file.close()
+			os.unlink(redacted_path)
+
+	def test_metadata(self):
+		redacted_fd, redacted_path = tempfile.mkstemp(".pdf")
+		redacted_file = os.fdopen(redacted_fd, "wb")
+		try:
+			with open(FIXTURE_PATH, "rb") as f:
+				options = pdf_redactor.RedactorOptions()
+				options.input_stream = f
+				options.output_stream = redacted_file
+				options.metadata_filters = {
+					"Title": [lambda value: value.replace("test", "sentinel")],
+					"Subject": [lambda value: value[::-1]],
+					"DEFAULT": [lambda value: None],
+				}
+
+				pdf_redactor.redactor(options)
+				redacted_file.close()
+
+				metadata = subprocess.check_output(["pdfinfo", redacted_path])
+				self.assertIn(b"this is a sentinel", metadata)
+				self.assertIn(b"FDP a si", metadata)
+				self.assertNotIn(b"CreationDate", metadata)
+				self.assertNotIn(b"LibreOffice", metadata)
 		finally:
 			redacted_file.close()
 			os.unlink(redacted_path)

--- a/tests/test_redactor.py
+++ b/tests/test_redactor.py
@@ -1,0 +1,40 @@
+import os
+import pkg_resources
+import re
+import tempfile
+import textract
+import unittest
+
+import pdf_redactor
+
+FIXTURE_PATH = pkg_resources.resource_filename(__name__, "test-ssns.pdf")
+
+
+class RedactorTest(unittest.TestCase):
+	def test_text_ssns(self):
+		redacted_fd, redacted_path = tempfile.mkstemp(".pdf")
+		redacted_file = os.fdopen(redacted_fd, "wb")
+		try:
+			with open(FIXTURE_PATH, "rb") as f:
+				options = pdf_redactor.RedactorOptions()
+				options.input_stream = f
+				options.output_stream = redacted_file
+				options.content_filters = [
+					(
+						re.compile(r"[−–—~‐]"),
+						lambda m: "-"
+					),
+					(
+						re.compile(r"(?<!\d)(?!666|000|9\d{2})([OoIli0-9]{3})([\s-]?)(?!00)([OoIli0-9]{2})\2(?!0{4})([OoIli0-9]{4})(?!\d)"),
+						lambda m: "XXX-XX-XXXX"
+					),
+				]
+
+				pdf_redactor.redactor(options)
+				redacted_file.close()
+
+				text = textract.process(redacted_path)
+				self.assertIn(b"Here are some fake SSNs\n\nXXX-XX-XXXX\n--\n\nXXX-XX-XXXX XXX-XX-XXXX\n\nAnd some more with common OCR character substitutions:\nXXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX", text)
+		finally:
+			redacted_file.close()
+			os.unlink(redacted_path)

--- a/tests/test_redactor.py
+++ b/tests/test_redactor.py
@@ -12,86 +12,74 @@ import pdf_redactor
 FIXTURE_PATH = pkg_resources.resource_filename(__name__, "test-ssns.pdf")
 
 
+class RedactFixture(object):
+	def __init__(self, input_path, options):
+		self.input_path = input_path
+		self.options = options
+
+	def __enter__(self):
+		self.input_file = open(self.input_path, "rb")
+		self.options.input_stream = self.input_file
+
+		fd, self.redacted_path = tempfile.mkstemp(".pdf")
+		self.redacted_file = os.fdopen(fd, "wb")
+		self.options.output_stream = self.redacted_file
+
+		pdf_redactor.redactor(self.options)
+		self.redacted_file.close()
+
+		return self.redacted_path
+
+	def __exit__(self, exc_type, exc_val, exc_tb):
+		self.input_file.close()
+		self.redacted_file.close()
+		os.unlink(self.redacted_path)
+		return False
+
+
 class RedactorTest(unittest.TestCase):
 	def test_text_ssns(self):
-		redacted_fd, redacted_path = tempfile.mkstemp(".pdf")
-		redacted_file = os.fdopen(redacted_fd, "wb")
-		try:
-			with open(FIXTURE_PATH, "rb") as f:
-				options = pdf_redactor.RedactorOptions()
-				options.input_stream = f
-				options.output_stream = redacted_file
-				options.content_filters = [
-					(
-						re.compile(u"[−–—~‐]"),
-						lambda m: "-"
-					),
-					(
-						re.compile(r"(?<!\d)(?!666|000|9\d{2})([OoIli0-9]{3})([\s-]?)(?!00)([OoIli0-9]{2})\2(?!0{4})([OoIli0-9]{4})(?!\d)"),
-						lambda m: "XXX-XX-XXXX"
-					),
-				]
-
-				pdf_redactor.redactor(options)
-				redacted_file.close()
-
-				text = textract.process(redacted_path)
-				self.assertIn(b"Here are some fake SSNs\n\nXXX-XX-XXXX\n--\n\nXXX-XX-XXXX XXX-XX-XXXX\n\nAnd some more with common OCR character substitutions:\nXXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX", text)
-		finally:
-			redacted_file.close()
-			os.unlink(redacted_path)
+		options = pdf_redactor.RedactorOptions()
+		options.content_filters = [
+			(
+				re.compile(u"[−–—~‐]"),
+				lambda m: "-"
+			),
+			(
+				re.compile(r"(?<!\d)(?!666|000|9\d{2})([OoIli0-9]{3})([\s-]?)(?!00)([OoIli0-9]{2})\2(?!0{4})([OoIli0-9]{4})(?!\d)"),
+				lambda m: "XXX-XX-XXXX"
+			),
+		]
+		with RedactFixture(FIXTURE_PATH, options) as redacted_path:
+			text = textract.process(redacted_path)
+			self.assertIn(b"Here are some fake SSNs\n\nXXX-XX-XXXX\n--\n\nXXX-XX-XXXX XXX-XX-XXXX\n\nAnd some more with common OCR character substitutions:\nXXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX XXX-XX-XXXX", text)
 
 	def test_metadata(self):
-		redacted_fd, redacted_path = tempfile.mkstemp(".pdf")
-		redacted_file = os.fdopen(redacted_fd, "wb")
-		try:
-			with open(FIXTURE_PATH, "rb") as f:
-				options = pdf_redactor.RedactorOptions()
-				options.input_stream = f
-				options.output_stream = redacted_file
-				options.metadata_filters = {
-					"Title": [lambda value: value.replace("test", "sentinel")],
-					"Subject": [lambda value: value[::-1]],
-					"DEFAULT": [lambda value: None],
-				}
-
-				pdf_redactor.redactor(options)
-				redacted_file.close()
-
-				metadata = subprocess.check_output(["pdfinfo", redacted_path])
-				self.assertIn(b"this is a sentinel", metadata)
-				self.assertIn(b"FDP a si", metadata)
-				self.assertNotIn(b"CreationDate", metadata)
-				self.assertNotIn(b"LibreOffice", metadata)
-		finally:
-			redacted_file.close()
-			os.unlink(redacted_path)
+		options = pdf_redactor.RedactorOptions()
+		options.metadata_filters = {
+			"Title": [lambda value: value.replace("test", "sentinel")],
+			"Subject": [lambda value: value[::-1]],
+			"DEFAULT": [lambda value: None],
+		}
+		with RedactFixture(FIXTURE_PATH, options) as redacted_path:
+			metadata = subprocess.check_output(["pdfinfo", redacted_path])
+			self.assertIn(b"this is a sentinel", metadata)
+			self.assertIn(b"FDP a si", metadata)
+			self.assertNotIn(b"CreationDate", metadata)
+			self.assertNotIn(b"LibreOffice", metadata)
 
 	def test_xmp(self):
+		options = pdf_redactor.RedactorOptions()
+		options.metadata_filters = {
+			"DEFAULT": [lambda value: None],
+		}
 		def xmp_filter(doc):
 			for elem in doc.iter():
 				if elem.text == "Writer":
 					elem.text = "Sentinel"
 			return doc
-
-		redacted_fd, redacted_path = tempfile.mkstemp(".pdf")
-		redacted_file = os.fdopen(redacted_fd, "wb")
-		try:
-			with open(FIXTURE_PATH, "rb") as f:
-				options = pdf_redactor.RedactorOptions()
-				options.input_stream = f
-				options.output_stream = redacted_file
-				options.metadata_filters = {
-					"DEFAULT": [lambda value: None],
-				}
-				options.xmp_filters = [xmp_filter]
-
-				pdf_redactor.redactor(options)
-				redacted_file.close()
-
-				metadata = subprocess.check_output(["pdfinfo", "-meta", redacted_path])
-				self.assertIn(b"Sentinel", metadata)
-				self.assertNotIn(b"Writer", metadata)
-		finally:
-			redacted_file.close()
-			os.unlink(redacted_path)
+		options.xmp_filters = [xmp_filter]
+		with RedactFixture(FIXTURE_PATH, options) as redacted_path:
+			metadata = subprocess.check_output(["pdfinfo", "-meta", redacted_path])
+			self.assertIn(b"Sentinel", metadata)
+			self.assertNotIn(b"Writer", metadata)

--- a/tests/test_redactor.py
+++ b/tests/test_redactor.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import os
 import pkg_resources
 import re

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py27, py34, py35
+
+[testenv]
+commands = python {toxinidir}/setup.py test
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py34]
+basepython = python3.4
+
+[testenv:py35]
+basepython = python3.5


### PR DESCRIPTION
This adds regression testing to the module, with some other goodies along the way. I added a setup.py script to facilitate this. Tests can be run directly with `nosetests` or `python setup.py test`, and you can test both Python 2 and Python 3 simultaneously by running `tox`. Furthermore, I added configuration to run the test suite on Travis CI. (also on multiple Python versions) [See results here.](https://travis-ci.org/divergentdave/pdf-redactor)

Along the way, I discovered that the example.py script didn't work correctly on Python 2. Due to encoding issues, the first text filter wasn't matching em dashes or en dashes. I changed a string constant to be a unicode constant, and it works now.

`pdfrw` recently released a new package, version 0.3, and that is currently even with `master` in the repository, so I switched the dependency to use the PyPI version. This should be better for both local caching and stability against upstream updates.